### PR TITLE
feat: add `pre_hook` and `post_hook` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ The default configuration options:
 require("auto-hlsearch").setup({
   remap_keys = { "/", "?", "*", "#", "n", "N" },
   create_commands = true,
+  pre_hook = function() end,
+  post_hook = function() end,
 })
 ```
 
 The plugin introduces a user command `:AutoHlsearch` which would be prepended to the provided `remap_keys`.
+`pre_hook` and `post_hook` functions will activate before/after searching.
 
 For more information read [help](./doc/auto-hlsearch.txt) `:h auto-hlsearch.nvim`.

--- a/doc/auto-hlsearch.txt
+++ b/doc/auto-hlsearch.txt
@@ -90,12 +90,12 @@ CONFIGURATION                                    *auto-hlsearch-configuration*
     Default: `true`
 
   pre_hook ~
-    Accepts a lua function which will executed before searching.
+    Accepts a lua function which will be executed before searching.
     Type: `function`
     Default: `function() end`
 
   post_hook ~
-    Accepts a lua function which will executed after searching.
+    Accepts a lua function which will be executed after searching.
     Type: `function`
     Default: `function() end`
 

--- a/doc/auto-hlsearch.txt
+++ b/doc/auto-hlsearch.txt
@@ -35,6 +35,8 @@ table with the settings you want to override. The defaults are the following:
 		       require("auto-hlsearch").setup({
 		         remap_keys = { "/", "?", "*", "#", "n", "N" },
 		         create_commands = true,
+		         pre_hook = function() end,
+		         post_hook = function() end,
 		       })
 <
 
@@ -86,6 +88,16 @@ CONFIGURATION                                    *auto-hlsearch-configuration*
     would still be available via lua API functions.
     Type: `boolean`
     Default: `true`
+
+  pre_hook ~
+    Accepts a lua function which will executed before searching.
+    Type: `function`
+    Default: `function() end`
+
+  post_hook ~
+    Accepts a lua function which will executed after searching.
+    Type: `function`
+    Default: `function() end`
 
 
 

--- a/lua/auto-hlsearch.lua
+++ b/lua/auto-hlsearch.lua
@@ -3,6 +3,8 @@ local M = {}
 local defaults = {
   remap_keys = { "/", "?", "*", "#", "n", "N" },
   create_commands = true,
+  pre_hook = function() end,
+  post_hook = function() end,
 }
 
 -- Remap provided keys in order to use activate() function
@@ -28,7 +30,7 @@ local function remap_keys(keys)
 
         -- For vimscript function, not use expr options
       elseif keymap.rhs then
-          vim.keymap.set("n", lhs, function () M.activate() return keymap.rhs end, opts)
+        vim.keymap.set("n", lhs, function () M.activate() return keymap.rhs end, opts)
 
       end
 
@@ -67,12 +69,14 @@ local function init(config)
 
     vim.o.hlsearch = false
     clear_subscriptions()
+    config.post_hook()
   end
 
   local function activate()
     -- there is no need to activate :AutoHlsearch again
     -- if the subscriptions are still present
     if #autocmd_ids ~= 0 then return end
+    config.pre_hook()
     vim.o.hlsearch = true
 
     local last_key = nil
@@ -130,6 +134,12 @@ local function apply_user_config(user_config)
     end
     if type(user_config.create_commands) == "boolean" then
       config.create_commands = user_config.create_commands
+    end
+    if type(user_config.pre_hook) == "function" then
+      config.pre_hook = user_config.pre_hook
+    end
+    if type(user_config.post_hook) == "function" then
+      config.post_hook = user_config.post_hook
     end
   end
 


### PR DESCRIPTION
Having these hooks will help users to customize the behavior of this plugin.

Typical usage is integrating [noice.nvim](https://github.com/folke/noice.nvim). Users can clear the Noice's search count message when search ends (when `M.disable()` is called.)